### PR TITLE
configurator.callbacks.compat.api.json: Add required callbacks for Lu…

### DIFF
--- a/files/sysbus/configurator.callbacks.compat.api.json
+++ b/files/sysbus/configurator.callbacks.compat.api.json
@@ -4,6 +4,16 @@
     "com.palm.lunabus/signal/registerServerStatus",
     "com.webos.appUpdateService/check",
     "com.webos.notification/purgeHistory",
-    "com.webos.service.bus/signal/registerServerStatus"
+    "com.webos.service.bus/signal/registerServerStatus",
+    "com.palm.applicationManager/launch",
+    "com.palm.service.calendar.reminders/onInit",
+    "com.palm.telephony/internal/sendSmsFromDb",
+    "com.palm.service.contacts.linker/dbUpdatedRelinkChanges",
+    "org.webosports.service.messaging/assignMessages",
+    "com.palm.imlibpurple/loginStateChanged",
+    "com.palm.imlibpurple/sendIM",
+    "com.palm.imlibpurple/sendCommand",
+    "com.palm.service.contacts/sortOrderChanged",
+    "org.webosports.service.update/checkUpdate"
   ]
 }


### PR DESCRIPTION
…neOS

Fixes:

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.app.calendar/com.palm.app.calendar.startreminders.json","error":13} /etc/palm/activities/com.palm.app.calendar/com.palm.app.calendar.startreminders.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.app.calendar/com.palm.app.calendar.firstrun.json","error":13} /etc/palm/activities/com.palm.app.calendar/com.palm.app.calendar.firstrun.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.telephony/outgoing-sms.json","error":13} /etc/palm/activities/com.palm.telephony/outgoing-sms.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.service.contacts.linker/com.palm.service.contacts.linker.json","error":13} /etc/palm/activities/com.palm.service.contacts.linker/com.palm.service.contacts.linker.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/org.webosports.service.messaging/org.webosports.service.messaging.assignMessages.json","error":13} /etc/palm/activities/org.webosports.service.messaging/org.webosports.service.messaging.assignMessages.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.imlibpurple/com.palm.immessage.libpurple","error":13} /etc/palm/activities/com.palm.imlibpurple/com.palm.immessage.libpurple: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.imlibpurple/com.palm.imcommand.libpurple","error":13} /etc/palm/activities/com.palm.imlibpurple/com.palm.imcommand.libpurple: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.imlibpurple/com.palm.imloginstate.libpurple","error":13} /etc/palm/activities/com.palm.imlibpurple/com.palm.imloginstate.libpurple: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/com.palm.service.contacts/com.palm.service.contacts.sortorder.json","error":13} /etc/palm/activities/com.palm.service.contacts/com.palm.service.contacts.sortorder.json: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Configurator CONFIGURATOR_ERROR {"config":"/etc/palm/activities/org.webosports.service.update/org.webosports.service.update.check","error":13} /etc/palm/activities/org.webosports.service.update/org.webosports.service.update.check: {"errorCode":13,"errorText":"'com.palm.configurator' doesn't have rights to call callback/trigger","returnValue":false} (MojErr: 13)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>